### PR TITLE
Fix timezone configuration to Europe/Paris

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -23,5 +23,5 @@ jobs:
           github-token: ${{ secrets.SCHEDULE_TOKEN }}
           date: ${{ github.event.inputs.date }}
           workflow: 'deb.yml'
-          timezone: 'EU/Paris' # US/Central, US/Pacific
+          timezone: 'Europe/Paris' # US/Central, US/Pacific
           wait-ms: 45000


### PR DESCRIPTION
EU/Paris is not an official IANA timezone, while Europe/Paris is, which cause the error "RangeError: Invalid time zone specified: EU/Paris".

